### PR TITLE
Proof of concept: Support for Django cached template loader.

### DIFF
--- a/djedi/loaders.py
+++ b/djedi/loaders.py
@@ -1,0 +1,23 @@
+from django.template.loaders.cached import Loader
+from .templatetags.djedi_tags import DjediNode
+
+
+class DjediRefresherMixin(object):
+    """
+    This mixin automatically refreshes each Djedi node for every
+    loaded template. Comes very handy in combination with caching template
+    loaders (ie `django.template.loaders.cached.Loader`).
+    """
+    def load_template(self, template_name, template_dirs=None):
+        template, origin = super(DjediRefresherMixin, self).load_template(
+            template_name, template_dirs)
+        djedi_nodes = template.nodelist.get_nodes_by_type(DjediNode)
+        map(lambda n: n.reload_node(), djedi_nodes)
+        return template, origin
+
+
+class DjediCachedLoader(DjediRefresherMixin, Loader):
+    """
+    Standard Django cached template loader with support for Djedi nodes.
+    """
+    pass


### PR DESCRIPTION
In the current version, Djedi is completely useless when using the Django cached template loader. The reason is that Djedi currently relies on the nodes being instantiated on each request. When using the cached loader the nodes are instantiated only on the first template load and being cached until the template cache is cleared. When using cached loaders, it's neither possible to edit nodes using the editor nor will they reflect language changes.

This patch provides a new template loader, DjediCachedLoader, that can be used as a drop-in replacement for the builtin Django cached template loader. It solves the described problem by refreshing each Djedi node on every template load.

To-do:
- [ ] Figure an elegant way to run tests using different template loaders
- [ ] Move the template loaders to a better place
- [ ] The lazy_tag decorator is no longer needed. We should probably deprecate it.
- [ ] Document the new cached loader.
