### PR TITLE
Make the tests run on Django 1.7 and Python 2.6

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -15,6 +15,10 @@ def main():
     unittest2.defaultTestLoader.discover('djedi')
 
     # Run tests
+    import django
+    if hasattr(django, 'setup'):
+        django.setup()
+
     from django.test.simple import DjangoTestSuiteRunner
     runner = DjangoTestSuiteRunner(verbosity=1, interactive=True, failfast=False)
     exit_code = runner.run_tests(['djedi'])

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 tests_require = [
     'unittest2',
     'coverage',
-    'Markdown',
+    'Markdown <= 2.4.1',
     'Pillow'
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26_django14, py27_django14, py26_django15, py27_django15, py26_django16, py27_django16
+envlist = py26_django14, py27_django14, py26_django15, py27_django15, py26_django16,
+          py27_django16, py27_django17
 
 [testenv]
 commands = {envpython} setup.py test
@@ -32,3 +33,7 @@ deps = Django==1.6
 [testenv:py27_django16]
 basepython = python2.7
 deps = Django==1.6
+
+[testenv:py27_django17]
+basepython = python2.7
+deps = Django==1.7


### PR DESCRIPTION
This pull requests does the following:

- Adds a new test env for Django 1.7
- Adds the now required django.setup() call to the test runner
- Pins the Markdown requirement (for tests only) to the last version of Markdown supporting Python 2.6.