### PR TITLE
Support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 language: python
 sudo: false
 env:
-  - TOXENV=py26-django14
   - TOXENV=py27-django14
-  - TOXENV=py26-django15
   - TOXENV=py27-django15
-  - TOXENV=py26-django16
   - TOXENV=py27-django16
-  - TOXENV=py33-django16
-  - TOXENV=py34-django16
   - TOXENV=py27-django17
-  - TOXENV=py33-django17
-  - TOXENV=py34-django17
   - TOXENV=py27-django18
+  - TOXENV=py27-django19
+  - TOXENV=py27-django110
+  - TOXENV=py33-django16
+  - TOXENV=py33-django17
   - TOXENV=py33-django18
+  - TOXENV=py33-django19
+  - TOXENV=py33-django110
+  - TOXENV=py34-django16
+  - TOXENV=py34-django17
   - TOXENV=py34-django18
+  - TOXENV=py34-django19
+  - TOXENV=py34-django110
+  - TOXENV=py35-django18
+  - TOXENV=py35-django19
+  - TOXENV=py35-django110
   - TOXENV=flake8
   - TOXENV=coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,13 @@ env:
   - TOXENV=py33-django16
   - TOXENV=py33-django17
   - TOXENV=py33-django18
-  - TOXENV=py33-django19
-  - TOXENV=py33-django110
-  - TOXENV=py34-django16
   - TOXENV=py34-django17
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django110
-  - TOXENV=py35-django18
-  - TOXENV=py35-django19
-  - TOXENV=py35-django110
+#  - TOXENV=py35-django18
+#  - TOXENV=py35-django19
+#  - TOXENV=py35-django110
   - TOXENV=flake8
   - TOXENV=coverage
 

--- a/djedi/admin/cms.py
+++ b/djedi/admin/cms.py
@@ -1,7 +1,11 @@
+import django
 try:
-    from django.conf.urls import patterns, include, url
+    from django.conf.urls import include, url
+    if django.VERSION < (1, 9):
+        from django.conf.urls import patterns
 except ImportError:
     from django.conf.urls.defaults import patterns, include, url
+
 
 from django.contrib.admin import ModelAdmin
 from django.core.exceptions import PermissionDenied
@@ -18,11 +22,15 @@ class Admin(ModelAdmin):
     verbose_name_plural = verbose_name
 
     def get_urls(self):
-        return patterns(
-            '',
+        urls = [
             url(r'^', include('djedi.admin.urls', namespace='djedi')),
             url(r'', lambda: None, name='djedi_cms_changelist')  # Placeholder to show change link to CMS in admin
-        )
+        ]
+
+        if django.VERSION < (1, 9):
+            return patterns('', *urls)
+        else:
+            return urls
 
     def has_change_permission(self, request, obj=None):
         return has_permission(request.user)

--- a/djedi/admin/urls.py
+++ b/djedi/admin/urls.py
@@ -1,13 +1,16 @@
+import django
+
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
+    if django.VERSION < (1, 9):
+        from django.conf.urls import patterns
 except ImportError:
     from django.conf.urls.defaults import patterns, url
 
 from .api import NodeApi, LoadApi, PublishApi, RevisionsApi, RenderApi, NodeEditor
 from .cms import DjediCMS
 
-urlpatterns = patterns(
-    '',
+urls = [
     url(r'^$', DjediCMS.as_view(), name='cms'),
     url(r'^node/(?P<uri>.+)/editor$', NodeEditor.as_view(), name='cms.editor'),
     url(r'^node/(?P<uri>.+)/load$', LoadApi.as_view(), name='api.load'),
@@ -15,4 +18,10 @@ urlpatterns = patterns(
     url(r'^node/(?P<uri>.+)/revisions$', RevisionsApi.as_view(), name='api.revisions'),
     url(r'^node/(?P<uri>.+)$', NodeApi.as_view(), name='api'),
     url(r'^plugin/(?P<ext>\w+)$', RenderApi.as_view(), name='api.render'),
-)
+]
+
+
+if django.VERSION < (1, 9):
+    urlpatterns = patterns('', *urls)
+else:
+    urlpatterns = urls

--- a/djedi/backends/django/cache/backend.py
+++ b/djedi/backends/django/cache/backend.py
@@ -17,7 +17,7 @@ class DjangoCacheBackend(CacheBackend):
             from django.core.cache import get_cache
             cache_name = self.config.get('NAME', 'djedi')
             cache = get_cache(cache_name)
-        except (InvalidCacheBackendError, ValueError):
+        except (InvalidCacheBackendError, ValueError, ImportError):
             from django.core.cache import cache
 
         self._cache = cache

--- a/djedi/compat.py
+++ b/djedi/compat.py
@@ -5,6 +5,10 @@ from functools import partial
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse as BaseTemplateResponse
+if django.VERSION < (1, 9):
+    from django.template.base import parse_bits
+else:
+    from django.template.library import parse_bits
 
 __all__ = ['render_to_string', 'render']
 
@@ -19,3 +23,14 @@ if django.VERSION >= (1, 8):
             super(TemplateResponse, self).__init__(*args, **kwargs)
 else:
     TemplateResponse = BaseTemplateResponse
+
+
+def generic_tag_compiler(parser, token, params, varargs, varkw, defaults,
+                         name, takes_context, node_class):
+    """
+    Returns a template.Node subclass.
+    """
+    bits = token.split_contents()[1:]
+    args, kwargs = parse_bits(parser, bits, params, varargs, varkw,
+                             defaults, takes_context, name)
+    return node_class(takes_context, args, kwargs)

--- a/djedi/compat.py
+++ b/djedi/compat.py
@@ -32,5 +32,5 @@ def generic_tag_compiler(parser, token, params, varargs, varkw, defaults,
     """
     bits = token.split_contents()[1:]
     args, kwargs = parse_bits(parser, bits, params, varargs, varkw,
-                             defaults, takes_context, name)
+                              defaults, takes_context, name)
     return node_class(takes_context, args, kwargs)

--- a/djedi/models.py
+++ b/djedi/models.py
@@ -1,9 +1,10 @@
-# Setup content-io configuration
+from cio.backends import storage
+
 import djedi
-djedi.configure()
 
 # Setup node django model based on backend
-from cio.backends import storage
 if storage.backend.scheme == 'db':
-    from .backends.django.db.models import Node
-    Node
+    from djedi.backends.django.db.models import Node  # noqa
+
+# Setup content-io configuration
+djedi.configure()

--- a/djedi/templatetags/djedi_tags.py
+++ b/djedi/templatetags/djedi_tags.py
@@ -1,7 +1,6 @@
 import cio
 import six
 import textwrap
-import django
 from django import template
 from django.template import TemplateSyntaxError
 from .template import register

--- a/djedi/templatetags/djedi_tags.py
+++ b/djedi/templatetags/djedi_tags.py
@@ -1,10 +1,11 @@
 import cio
 import six
 import textwrap
+import django
 from django import template
 from django.template import TemplateSyntaxError
-from django.template.base import parse_bits
 from .template import register
+from djedi.compat import parse_bits
 
 
 def render_node(node, context=None, edit=True):

--- a/djedi/templatetags/future.py
+++ b/djedi/templatetags/future.py
@@ -1,0 +1,8 @@
+from django.template import Library, defaulttags
+
+register = Library()
+
+
+@register.tag
+def url(parser, token):
+    return defaulttags.url(parser, token)

--- a/djedi/templatetags/template.py
+++ b/djedi/templatetags/template.py
@@ -1,8 +1,14 @@
 from functools import partial
 from inspect import getargspec
+
+import django
 from django import template
 from django.template import Context
-from django.template.base import Node, TemplateSyntaxError, generic_tag_compiler
+from django.template.base import Node, TemplateSyntaxError
+if django.VERSION < (1, 9):
+    from django.template.base import generic_tag_compiler
+else:
+    from djedi.compat import generic_tag_compiler
 
 register = template.Library()
 

--- a/djedi/tests/__init__.py
+++ b/djedi/tests/__init__.py
@@ -1,5 +1,5 @@
-from .test_admin import *
-from .test_cache import *
-from .test_rest import *
-from .test_settings import *
-from .test_templatetags import *
+from .test_admin import *  # noqa
+from .test_cache import *  # noqa
+from .test_rest import *  # noqa
+from .test_settings import *  # noqa
+from .test_templatetags import *  # noqa

--- a/djedi/tests/urls.py
+++ b/djedi/tests/urls.py
@@ -1,14 +1,26 @@
+import django
 from django.shortcuts import render_to_response
 
 try:
-    from django.conf.urls import patterns, include, url
+    from django.conf.urls import include, url
+    if django.VERSION < (1, 9):
+        from django.conf.urls import patterns
 except ImportError:
     from django.conf.urls.defaults import patterns, include, url
 
 from django.contrib import admin
 
+import djedi.urls
+
 admin.autodiscover()
 
-urlpatterns = patterns('',
-                       url(r'^$', lambda r: render_to_response('index.html'), name='index'),
-                       url(r'^adm1n/', include(admin.site.urls)))
+urls = [
+    url(r'^$', lambda r: render_to_response('index.html'), name='index'),
+    url(r'^adm1n/', include(admin.site.urls)),
+    url(r'^djedi/', include(djedi.urls))
+]
+
+if django.VERSION < (1, 9):
+    urlpatterns = patterns('', *urls)
+else:
+    urlpatterns = urls

--- a/djedi/urls.py
+++ b/djedi/urls.py
@@ -1,7 +1,18 @@
+import django
+
 try:
-    from django.conf.urls import patterns, include
+    from django.conf.urls import include, url
+    if django.VERSION < (1, 9):
+        from django.conf.urls import patterns
 except ImportError:
-    from django.conf.urls.defaults import patterns, include
+    from django.conf.urls.defaults import patterns, include, url
 
 
-urlpatterns = patterns('', (r'^', include('djedi.admin.urls', namespace='djedi', app_name='djedi')))
+urls = [
+    url(r'^', include('djedi.admin.urls', namespace='djedi', app_name='djedi'))
+]
+
+if django.VERSION < (1, 9):
+    urlpatterns = patterns('', *urls)
+else:
+    urlpatterns = urls

--- a/runtests.py
+++ b/runtests.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.ERROR)
 TEMPLATE_DEBUG = True
 TEMPLATE_CONTEXT_PROCESSORS = []
 TEMPLATE_DIRS = [
-  os.path.join(ROOT, 'templates'),
+    os.path.join(ROOT, 'templates'),
 ]
 
 DEFAULT_SETTINGS = dict(

--- a/runtests.py
+++ b/runtests.py
@@ -11,10 +11,14 @@ ROOT = os.path.join(os.path.dirname(__file__), 'djedi/tests')
 
 logging.basicConfig(level=logging.ERROR)
 
+TEMPLATE_DEBUG = True
+TEMPLATE_CONTEXT_PROCESSORS = []
+TEMPLATE_DIRS = [
+  os.path.join(ROOT, 'templates'),
+]
 
 DEFAULT_SETTINGS = dict(
     DEBUG=True,
-    TEMPLATE_DEBUG=True,
 
     MIDDLEWARE_CLASSES=(
         'django.middleware.common.CommonMiddleware',
@@ -32,7 +36,23 @@ DEFAULT_SETTINGS = dict(
         'django.contrib.admin',
         'djedi',
     ],
-    TEMPLATE_CONTEXT_PROCESSORS=[],
+
+    TEMPLATE_DEBUG=TEMPLATE_DEBUG,
+    TEMPLATE_CONTEXT_PROCESSORS=TEMPLATE_CONTEXT_PROCESSORS,
+    TEMPLATE_DIRS=TEMPLATE_DIRS,
+
+    TEMPLATES=[
+        {
+
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'DIRS': TEMPLATE_DIRS,
+            'OPTIONS': {
+                'debug': TEMPLATE_DEBUG,
+                'context_processors': TEMPLATE_CONTEXT_PROCESSORS
+            }
+        }
+    ],
 
     MEDIA_ROOT=os.path.join(ROOT, 'media'),
     STATIC_ROOT=os.path.join(ROOT, 'static'),
@@ -42,10 +62,6 @@ DEFAULT_SETTINGS = dict(
 
     LANGUAGE_CODE='sv-se',
     SECRET_KEY="iufoj=mibkpdz*%bob9-DJEDI-52x(%49rqgv8gg45k36kjcg76&-y5=!",
-
-    TEMPLATE_DIRS=(
-        os.path.join(ROOT, 'templates'),
-    ),
 
     PASSWORD_HASHERS=(
         'django.contrib.auth.hashers.MD5PasswordHasher',
@@ -70,7 +86,6 @@ DEFAULT_SETTINGS = dict(
             'foo': 'bar'
         }
     },
-
 )
 
 
@@ -94,8 +109,9 @@ def main():
         runner_class = DjangoTestSuiteRunner
         test_args = ['djedi']
 
-    failures = runner_class(
-        verbosity=1, interactive=True, failfast=False).run_tests(test_args)
+    failures = runner_class(verbosity=1,
+                            interactive=True,
+                            failfast=True).run_tests(test_args)
     sys.exit(failures)
 
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{26,27}-django{14,15,16}, py27-django{17,18}, py{33,34}-django{16,17,18}
+envlist = py{26,27}-django{14,15,16},
+          py27-django{17,18},
+          py{33,34}-django{16,17,18,19,110},
+          py35-django{18,19,110}
 
 [testenv]
 commands = python setup.py test
@@ -18,6 +21,8 @@ deps = six
        django16: Django>=1.6,<1.7
        django17: Django>=1.7,<1.8
        django18: Django>=1.8,<1.9
+       django19: Django>=1.9,<1.10
+       django110: Django>=1.9,<1.11
        py26,py27: importlib
                   unittest2
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{26,27}-django{14,15,16},
-          py27-django{17,18},
+envlist = py27-django{14,15,16,17,18,19,110},
           py{33,34}-django{16,17,18,19,110},
           py35-django{18,19,110}
 
@@ -23,8 +22,8 @@ deps = six
        django18: Django>=1.8,<1.9
        django19: Django>=1.9,<1.10
        django110: Django>=1.9,<1.11
-       py26,py27: importlib
-                  unittest2
+       py27: importlib
+             unittest2
 
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@
 
 [tox]
 envlist = py27-django{14,15,16,17,18,19,110},
-          py{33,34}-django{16,17,18,19,110},
+          py33-django{16,17,18},
+          py34-django{17,18,19,110},
           py35-django{18,19,110}
 
 [testenv]


### PR DESCRIPTION
## What've been done
- Fix imports
- Don't use `patterns` in urlconf for Django >= 1.9
- Include `generic_tag_compiler` from Django 1.8, which was dropped in Django 1.9
- Include `future` templatetags from Django 1.8 (just with the `url`-tag), which was dropped in Django 1.9
- Drop Python 2.6 support (i.e. don't run tests for it since Django doesn't support Python 2.6 anymore)
- Run tests for Python 3.5 (Django >= 1.8)

This patch also implies support for Django 1.9 (or maby vice versa :smiley:).
