### PR TITLE
Support Django 1.9 -> 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 sudo: false
 env:
-  - TOXENV=py26-django14
-  - TOXENV=py27-django14
   - TOXENV=py26-django15
   - TOXENV=py27-django15
   - TOXENV=py26-django16
@@ -15,6 +13,12 @@ env:
   - TOXENV=py27-django18
   - TOXENV=py33-django18
   - TOXENV=py34-django18
+  - TOXENV=py27-django19
+  - TOXENV=py34-django19
+  - TOXENV=py27-django110
+  - TOXENV=py34-django110
+  - TOXENV=py27-django111
+  - TOXENV=py34-django111
   - TOXENV=flake8
   - TOXENV=coverage
 

--- a/djedi/admin/cms.py
+++ b/djedi/admin/cms.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import patterns, include, url
+    from django.conf.urls import include, url
 except ImportError:
-    from django.conf.urls.defaults import patterns, include, url
+    from django.conf.urls.defaults import include, url
 
 from django.contrib.admin import ModelAdmin
 from django.core.exceptions import PermissionDenied
@@ -10,6 +10,7 @@ from django.views.generic import View
 from .mixins import DjediContextMixin
 from ..auth import has_permission
 from ..compat import render
+from ..compat import urlpatterns
 
 
 class Admin(ModelAdmin):
@@ -18,8 +19,7 @@ class Admin(ModelAdmin):
     verbose_name_plural = verbose_name
 
     def get_urls(self):
-        return patterns(
-            '',
+        return urlpatterns(
             url(r'^', include('djedi.admin.urls', namespace='djedi')),
             url(r'', lambda: None, name='djedi_cms_changelist')  # Placeholder to show change link to CMS in admin
         )

--- a/djedi/admin/urls.py
+++ b/djedi/admin/urls.py
@@ -1,13 +1,14 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
+
+from ..compat import urlpatterns
 
 from .api import NodeApi, LoadApi, PublishApi, RevisionsApi, RenderApi, NodeEditor
 from .cms import DjediCMS
 
-urlpatterns = patterns(
-    '',
+urlpatterns = urlpatterns(
     url(r'^$', DjediCMS.as_view(), name='cms'),
     url(r'^node/(?P<uri>.+)/editor$', NodeEditor.as_view(), name='cms.editor'),
     url(r'^node/(?P<uri>.+)/load$', LoadApi.as_view(), name='api.load'),

--- a/djedi/backends/django/cache/backend.py
+++ b/djedi/backends/django/cache/backend.py
@@ -17,7 +17,7 @@ class DjangoCacheBackend(CacheBackend):
             from django.core.cache import get_cache
             cache_name = self.config.get('NAME', 'djedi')
             cache = get_cache(cache_name)
-        except (InvalidCacheBackendError, ValueError):
+        except (InvalidCacheBackendError, ValueError, ImportError):
             from django.core.cache import cache
 
         self._cache = cache

--- a/djedi/compat.py
+++ b/djedi/compat.py
@@ -6,7 +6,40 @@ from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse as BaseTemplateResponse
 
-__all__ = ['render_to_string', 'render']
+
+def urlpatterns(*urls):
+    if django.VERSION < (1, 10):
+        try:
+            from django.conf.urls.defaults import patterns
+        except ImportError:
+            from django.conf.urls import patterns
+
+        return patterns('', *urls)
+
+    # else
+    return list(urls)
+
+
+if django.VERSION >= (1, 9):
+    from django.template.library import parse_bits
+
+    def generic_tag_compiler(parser, token, params, varargs, varkw, defaults,
+                             name, takes_context, node_class):
+        """
+        Returns a template.Node subclass.
+
+        This got inlined into django.template.library since Django since 1.9, this here
+        is a copypasta replacement:
+        https://github.com/django/django/blob/stable/1.8.x/django/template/base.py#L1089
+        """
+        bits = token.split_contents()[1:]
+        args, kwargs = parse_bits(parser, bits, params, varargs, varkw,
+                                  defaults, takes_context, name)
+        return node_class(takes_context, args, kwargs)
+else:
+    from django.template.base import parse_bits
+    from django.template.base import generic_tag_compiler  # noqa
+
 
 if django.VERSION >= (1, 8):
     # Always use the Django template engine on Django 1.8.
@@ -19,3 +52,9 @@ if django.VERSION >= (1, 8):
             super(TemplateResponse, self).__init__(*args, **kwargs)
 else:
     TemplateResponse = BaseTemplateResponse
+
+__all__ = ['render_to_string',
+           'render',
+           'urlpatterns',
+           'generic_tag_compiler',
+           'parse_bits']

--- a/djedi/templates/djedi/cms/embed.html
+++ b/djedi/templates/djedi/cms/embed.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <script>window.DJEDI_NODES = {{ json_nodes|safe }};</script>
 <style type="text/css">
 #djedi-cms{position:fixed;top:0;right:-400px;width:400px;height:100%;border:0;z-index:30000}#djedi-cms.fullscreen{width:100%}

--- a/djedi/templates/djedi/plugins/base/editor.html
+++ b/djedi/templates/djedi/plugins/base/editor.html
@@ -1,5 +1,4 @@
 {% load static staticfiles %}
-{% load url from future %}
 <!DOCTYPE html>
 <html>
     <head>

--- a/djedi/templatetags/djedi_tags.py
+++ b/djedi/templatetags/djedi_tags.py
@@ -3,8 +3,8 @@ import six
 import textwrap
 from django import template
 from django.template import TemplateSyntaxError
-from django.template.base import parse_bits
 from .template import register
+from ..compat import parse_bits
 
 
 def render_node(node, context=None, edit=True):

--- a/djedi/templatetags/template.py
+++ b/djedi/templatetags/template.py
@@ -2,7 +2,9 @@ from functools import partial
 from inspect import getargspec
 from django import template
 from django.template import Context
-from django.template.base import Node, TemplateSyntaxError, generic_tag_compiler
+from django.template.base import Node, TemplateSyntaxError
+
+from ..compat import generic_tag_compiler
 
 register = template.Library()
 

--- a/djedi/tests/compat.py
+++ b/djedi/tests/compat.py
@@ -1,0 +1,12 @@
+import django
+
+
+def cmpt_context(context):
+    if django.VERSION >= (1, 8):
+        return context
+
+    from django.template import Context
+    return Context(context)
+
+
+__all__ = ['cmpt_context']

--- a/djedi/tests/test_templatetags.py
+++ b/djedi/tests/test_templatetags.py
@@ -1,10 +1,11 @@
 import cio
 from django.contrib.auth.models import User
-from django.template import Context, TemplateSyntaxError
+from django.template import TemplateSyntaxError
 from cio.backends import cache
 from cio.pipeline import pipeline
 from djedi.templatetags.template import register
 from djedi.tests.base import DjediTest, AssertionMixin
+from .compat import cmpt_context
 
 try:
     from django.template.loader import get_template_from_string
@@ -20,7 +21,7 @@ class TagTest(DjediTest, AssertionMixin):
 
     def render(self, source, context=None):
         source = u'{% load djedi_tags %}' + source.strip()
-        context = Context(context or {})
+        context = cmpt_context(context or {})
         return get_template_from_string(source).render(context).strip()
 
     def test_node_tag(self):

--- a/djedi/tests/urls.py
+++ b/djedi/tests/urls.py
@@ -1,14 +1,16 @@
 from django.shortcuts import render_to_response
 
 try:
-    from django.conf.urls import patterns, include, url
+    from django.conf.urls import include, url
 except ImportError:
-    from django.conf.urls.defaults import patterns, include, url
+    from django.conf.urls.defaults import include, url
 
 from django.contrib import admin
+from ..compat import urlpatterns
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
-                       url(r'^$', lambda r: render_to_response('index.html'), name='index'),
-                       url(r'^adm1n/', include(admin.site.urls)))
+urlpatterns = urlpatterns(
+    url(r'^$', lambda r: render_to_response('index.html'), name='index'),
+    url(r'^adm1n/', include(admin.site.urls))
+)

--- a/runtests.py
+++ b/runtests.py
@@ -14,7 +14,6 @@ logging.basicConfig(level=logging.ERROR)
 
 DEFAULT_SETTINGS = dict(
     DEBUG=True,
-    TEMPLATE_DEBUG=True,
 
     MIDDLEWARE_CLASSES=(
         'django.middleware.common.CommonMiddleware',
@@ -32,7 +31,6 @@ DEFAULT_SETTINGS = dict(
         'django.contrib.admin',
         'djedi',
     ],
-    TEMPLATE_CONTEXT_PROCESSORS=[],
 
     MEDIA_ROOT=os.path.join(ROOT, 'media'),
     STATIC_ROOT=os.path.join(ROOT, 'static'),
@@ -43,9 +41,24 @@ DEFAULT_SETTINGS = dict(
     LANGUAGE_CODE='sv-se',
     SECRET_KEY="iufoj=mibkpdz*%bob9-DJEDI-52x(%49rqgv8gg45k36kjcg76&-y5=!",
 
-    TEMPLATE_DIRS=(
-        os.path.join(ROOT, 'templates'),
-    ),
+    TEMPLATE_DEBUG=True,
+    TEMPLATE_CONTEXT_PROCESSORS=[],
+    TEMPLATE_DIRS=(os.path.join(ROOT, 'templates'),),
+
+    TEMPLATES=[
+        {
+
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'DIRS': (os.path.join(ROOT, 'templates'),),
+            'OPTIONS': {
+                'debug': True,
+                'context_processors': [
+                    'django.contrib.auth.context_processors.auth',
+                ]
+            }
+        }
+    ],
 
     PASSWORD_HASHERS=(
         'django.contrib.auth.hashers.MD5PasswordHasher',
@@ -95,7 +108,9 @@ def main():
         test_args = ['djedi']
 
     failures = runner_class(
-        verbosity=1, interactive=True, failfast=False).run_tests(test_args)
+        verbosity=1,
+        interactive=True,
+        failfast=False).run_tests(test_args)
     sys.exit(failures)
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
 tests_require = [
     'coverage',
     'Markdown <= 2.4.1',
-    'Pillow',
+    'Pillow <= 3.4.2',
 ]
 
 if version_info < (3,):

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py{26,27}-django{14,15,16}, py27-django{17,18}, py{33,34}-django{16,17
 commands = python setup.py test
 install_command = pip install --no-binary Django --pre {opts} {packages}
 deps = six
-       Pillow
+       Pillow<=3.4.2
        markdown<=2.4
        django-discover-runner
        django14: Django>=1.4,<1.5

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps = six
 [testenv:coverage]
 basepython = python2.7
 commands = coverage run --omit=migrations,south_migrations --source djedi setup.py test
+           coverage report
 deps = coverage
        python-coveralls
        Django>=1.8,<1.9

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{26,27}-django{14,15,16}, py27-django{17,18}, py{33,34}-django{16,17,18}
+envlist = py{26,27}-django{15,16}, py27-django{17,18,19,110,111}, py{33,34}-django{16,17,18,19,110,111}
 
 [testenv]
 commands = python setup.py test
@@ -13,11 +13,13 @@ deps = six
        Pillow<=3.4.2
        markdown<=2.4
        django-discover-runner
-       django14: Django>=1.4,<1.5
        django15: Django>=1.5,<1.6
        django16: Django>=1.6,<1.7
        django17: Django>=1.7,<1.8
        django18: Django>=1.8,<1.9
+       django19: Django>=1.9,<1.10
+       django110: Django>=1.10,<1.11
+       django111: Django>=1.11,<1.12
        py26,py27: importlib
                   unittest2
 


### PR DESCRIPTION
This also drops Django 1.4. It's possible to keep support but it'd require some template trickery, which might be bloat if 1.4 support is not required anymore.

Fixes #18