### PR TITLE
Remove unnecessary scrollbars in versions dropdown

### DIFF
--- a/djedi/static/djedi/themes/base/theme.less
+++ b/djedi/static/djedi/themes/base/theme.less
@@ -407,7 +407,7 @@ body.editor {
       border-color: #666;
       text-shadow: none;
       min-width: 80px;
-      overflow: scroll;
+      overflow: auto;
       max-height: 300px;
       margin-right: 45px;
 

--- a/djedi/static/djedi/themes/darth/theme.css
+++ b/djedi/static/djedi/themes/darth/theme.css
@@ -6358,7 +6358,7 @@ body.editor header .dropdown-menu {
   border-color: #666;
   text-shadow: none;
   min-width: 80px;
-  overflow: scroll;
+  overflow: auto;
   max-height: 300px;
   margin-right: 45px;
 }

--- a/djedi/static/djedi/themes/luke/theme.css
+++ b/djedi/static/djedi/themes/luke/theme.css
@@ -6358,7 +6358,7 @@ body.editor header .dropdown-menu {
   border-color: #666;
   text-shadow: none;
   min-width: 80px;
-  overflow: scroll;
+  overflow: auto;
   max-height: 300px;
   margin-right: 45px;
 }


### PR DESCRIPTION
This commit changes from `overflow: scroll` to `overflow: auto` so that
the scrollbars only appear if needed.

### Before

![screenshot from 2018-09-06 10-25-03](https://user-images.githubusercontent.com/2142817/45144817-771c1880-b1bf-11e8-889b-2bb67c6e501c.png)

### After

![screenshot from 2018-09-06 10-24-42](https://user-images.githubusercontent.com/2142817/45144829-80a58080-b1bf-11e8-8b00-2311b80a1774.png)

#### Scrollbars can still appear

![screenshot from 2018-09-06 10-24-13](https://user-images.githubusercontent.com/2142817/45144851-8dc26f80-b1bf-11e8-943c-a6e9839f9588.png)
