### PR TITLE
Fix race condition when clicking outlines to edit

### DIFF
--- a/djedi/static/djedi/cms/js/cms.coffee
+++ b/djedi/static/djedi/cms/js/cms.coffee
@@ -253,7 +253,7 @@ class Plugin
 
     # Create iframe
     @$el = $ '<iframe>'
-    @$el.on 'load', @connect
+    @$el.one 'load', @connect
     @navigate @uri
 
   navigate: (uri) ->
@@ -267,16 +267,14 @@ class Plugin
       alert 'Failed to load node'
       return
 
-    @window.$ =>
-      console.log 'Plugin.connect().loaded'
-      @$doc = @window.$ @window.document  # Local iframe jQuery document
+    @$doc = @window.$ @window.document  # Local iframe jQuery document
 
-      # Bind and catch/forward events from plugin
-      @$doc.on 'node:render', Events.handler
-      @$doc.on 'node:resize', Events.handler
-      @$doc.on 'page:node:fetch', (event, uri, callback) => callback data: @node.data, content: @node.getContent()
+    # Bind and catch/forward events from plugin
+    @$doc.on 'node:render', Events.handler
+    @$doc.on 'node:resize', Events.handler
+    @$doc.on 'page:node:fetch', (event, uri, callback) => callback data: @node.data, content: @node.getContent()
 
-      @render()
+    @render()
 
   render: ->
     # Resize and show frame

--- a/djedi/static/djedi/cms/js/cms.js
+++ b/djedi/static/djedi/cms/js/cms.js
@@ -337,7 +337,7 @@
       this.connect = __bind(this.connect, this);
       this.uri = this.node.uri.valueOf();
       this.$el = $('<iframe>');
-      this.$el.on('load', this.connect);
+      this.$el.one('load', this.connect);
       this.navigate(this.uri);
     }
 
@@ -352,21 +352,18 @@
         alert('Failed to load node');
         return;
       }
-      return this.window.$((function(_this) {
-        return function() {
-          console.log('Plugin.connect().loaded');
-          _this.$doc = _this.window.$(_this.window.document);
-          _this.$doc.on('node:render', Events.handler);
-          _this.$doc.on('node:resize', Events.handler);
-          _this.$doc.on('page:node:fetch', function(event, uri, callback) {
-            return callback({
-              data: _this.node.data,
-              content: _this.node.getContent()
-            });
+      this.$doc = this.window.$(this.window.document);
+      this.$doc.on('node:render', Events.handler);
+      this.$doc.on('node:resize', Events.handler);
+      this.$doc.on('page:node:fetch', (function(_this) {
+        return function(event, uri, callback) {
+          return callback({
+            data: _this.node.data,
+            content: _this.node.getContent()
           });
-          return _this.render();
         };
       })(this));
+      return this.render();
     };
 
     Plugin.prototype.render = function() {

--- a/djedi/static/djedi/plugins/base/js/editor.js
+++ b/djedi/static/djedi/plugins/base/js/editor.js
@@ -155,6 +155,7 @@
 
   window.Editor = (function() {
     function Editor(config) {
+      var _this = this;
       this.config = config;
       this.discard = __bind(this.discard, this);
       this.publish = __bind(this.publish, this);
@@ -162,7 +163,15 @@
       this.onSave = __bind(this.onSave, this);
       this.onFormChange = __bind(this.onFormChange, this);
       this.onLoad = __bind(this.onLoad, this);
-      this.initialize(this.config);
+      if (document.readyState === 'complete') {
+        this.initialize(this.config);
+      } else {
+        $(window).one('load', function() {
+          return setTimeout((function() {
+            return _this.initialize(_this.config);
+          }), 0);
+        });
+      }
     }
 
     Editor.prototype.initialize = function(config) {


### PR DESCRIPTION
Sometimes when clicking an outline for a node to edit it, the node is
blanked out. It still works to fill in some new text and save, but the
initial node text failed to load. This is due to a race condition. See the
comment added in the code for all the details.

Normally, these are the `console.log`s when clicking an outline:

```
cms.js?v=1.2.1:159 select node
cms.js?v=1.2.1:349 Plugin.connect()
cms.js?v=1.2.1:357 Plugin.connect().loaded
cms.js?v=1.2.1:378 Plugin.resize()
editor.js?v=1.2.1:232 Editor.onLoad() i18n://sv-se@home/test.md
editor.js?v=1.2.1:219 Editor.trigger page:node:fetch
editor.js?v=1.2.1:236 Editor.inititial data {data: "I like djedi!", content: "<p>I like djedi!</p>"}
editor.js?v=1.2.1:266 Editor.setNode()
editor.js?v=1.2.1:290 Editor.setState() new
editor.js?v=1.2.1:219 Editor.trigger page:node:fetch
editor.js?v=1.2.1:428 Editor.renderContent()
editor.js?v=1.2.1:362 Editor.renderRevisions()
editor.js?v=1.2.1:219 Editor.trigger plugin:loaded
editor.js?v=1.2.1:395 Editor.render()
editor.js?v=1.2.1:248 content <p>I like djedi!</p>
editor.js?v=1.2.1:219 Editor.trigger node:render
cms.js?v=1.2.1:16 Event node:render
cms.js?v=1.2.1:98 Node.render
```

But when the bug occurs, the logs are:

```
cms.js?v=1.2.1:159 select node
editor.js?v=1.2.1:232 Editor.onLoad() i18n://sv-se@home/test.md
editor.js?v=1.2.1:219 Editor.trigger page:node:fetch
editor.js?v=1.2.1:266 Editor.setNode()
editor.js?v=1.2.1:290 Editor.setState() new
editor.js?v=1.2.1:219 Editor.trigger page:node:fetch
editor.js?v=1.2.1:362 Editor.renderRevisions()
editor.js?v=1.2.1:219 Editor.trigger plugin:loaded
editor.js?v=1.2.1:395 Editor.render()
editor.js?v=1.2.1:248 content
cms.js?v=1.2.1:349 Plugin.connect()
cms.js?v=1.2.1:357 Plugin.connect().loaded
cms.js?v=1.2.1:378 Plugin.resize()
editor.js?v=1.2.1:219 Editor.trigger node:render
cms.js?v=1.2.1:16 Event node:render
```

Notice how `Editor.onLoad()` is called _before_ `Plugin.connect()`. This
means that when Editor (in editor.coffee) fires the 'page:node:fetch' event,
Plugin (in cms.coffee) hasn’t had the chance to subscribe to that event yet.

This commit fixes that race condition, by having editor.coffee wait for
cms.coffee to register its event handlers.

There was a jQuery "ready" handler inside a 'load' event callback in cms.coffee
that I removed because of two reasons. First off, it was unnecessary. When the
'load' event has fired the document _is_ ready. Secondly, I wanted to be 100%
sure that the code inside the "ready" handler runs _immediately_ when the 'load'
event fires, to avoid the race condition.

This was tested by temporarily replacing `Client#load` in cms.coffee with:

```coffee
load: (uri, callback) ->
  # @GET_JSON "node/#{@e(uri)}/load", callback
  Promise.resolve().then ->
    callback {
        "uri": "i18n://sv-se@home/test.md",
        "data": null,
        "content": null,
        "meta": {}
    }
```

The above forces the `Client#load` request to finish before the 'load' event.

I’ve also installed this commit on the site where I was hitting this problem, and it fixed the issue.