### PR TITLE
Changed textarea listener to 'input'

### DIFF
--- a/djedi/templates/djedi/plugins/md/editor.html
+++ b/djedi/templates/djedi/plugins/md/editor.html
@@ -33,7 +33,7 @@
                     }
                 });
 
-                editor.$textarea.on('keypress', function () {
+                editor.$textarea.on('input', function () {
                     editor.setState('dirty');
                 });
             },


### PR DESCRIPTION
- This will make 'non-character' keys like backspace to register as an input
- It listens to paste with CTRL/CMD + V
- It wont listen to keys that doesn't change the textarea at all like arrowkeys