### PR TITLE
Silence annoying 403 errors in browser dev tools

### DIFF
--- a/djedi-react/src/djedi.js
+++ b/djedi-react/src/djedi.js
@@ -257,6 +257,12 @@ export class Djedi {
     const url = `${this.options.baseUrl}/embed/`;
 
     return this._fetch(url, { credentials: "include" }).then(response => {
+      // If the user is not logged in as an admin, the API responds with 204 No
+      // Content. Also handle 403 Forbidden for backwards compatibility.
+      if (response.status === 204 || response.status === 403) {
+        return false;
+      }
+
       if (response.status >= 200 && response.status < 400) {
         return response.text().then(html => {
           // Browsers don’t allow <script> tags inserted as part of an HTML
@@ -276,9 +282,7 @@ export class Djedi {
           return true;
         });
       }
-      if (response.status === 403) {
-        return false;
-      }
+
       return Promise.reject(createStatusCodeError(response));
     });
   }

--- a/djedi-react/test/djedi.test.js
+++ b/djedi-react/test/djedi.test.js
@@ -539,6 +539,16 @@ describe("injectAdmin", () => {
   });
 
   test("handles not having permission", async () => {
+    fetch("", { status: 204, stringify: false });
+    document.body.innerHTML = "<p>Some content</p>";
+    const inserted = await djedi.injectAdmin();
+    expect(inserted).toBe(false);
+    expect(document.body.innerHTML).toMatchInlineSnapshot(
+      `"<p>Some content</p>"`
+    );
+  });
+
+  test("handles not having permission – backwards compatibility", async () => {
     fetch("<h1>403 Forbidden</h1>", { status: 403, stringify: false });
     document.body.innerHTML = "<p>Some content</p>";
     const inserted = await djedi.injectAdmin();

--- a/djedi/rest/api.py
+++ b/djedi/rest/api.py
@@ -1,6 +1,6 @@
 import simplejson as json
 import six
-from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
@@ -26,7 +26,11 @@ class EmbedApi(View):
         if has_permission(request):
             return render_embed(request=request)
         else:
-            raise PermissionDenied
+            # We used to `raise PermissionDenied` here (which might seem more
+            # appropriate), but that has the annoying side effect of being
+            # logged as an error in the browser dev tools, making people think
+            # something is wrong.
+            return HttpResponse(status=204)
 
 
 class NodesApi(APIView):

--- a/djedi/tests/test_rest.py
+++ b/djedi/tests/test_rest.py
@@ -293,7 +293,7 @@ class PublicRestTest(ClientTest):
 
         self.client.logout()
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 204)
 
     def test_nodes(self):
         with self.assertCache(sets=1):


### PR DESCRIPTION
This happens when trying to inject the admin via djedi-react. The API
responds with 403 if not logged in as an admin. While that might be an
appropriate status code, it is annoying to get red errors in the browser
console because of that “failed request.” Especially if you’re not super
familiar with djedi internals it looks like something is wrong. This
commit responds with 204 No Content instead.